### PR TITLE
Bugsnag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.1'
 
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'bugsnag'
 gem 'json-jwt', '~> 1.13'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,0 +1,4 @@
+Bugsnag.configure do |config|
+  config.api_key = ENV['BUGSNAG_API_KEY']
+  config.notify_release_stages = %w[production staging]
+end

--- a/config/template.rb
+++ b/config/template.rb
@@ -1,5 +1,6 @@
 copy_file 'config/initializers/generators.rb'
 copy_file 'config/initializers/rotate_log.rb'
+copy_file 'config/initializers/bugsnag.rb'
 
 apply 'config/environments/development.rb'
 apply 'config/environments/production.rb'

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
+BUGSNAG_API_KEY=bugsnag-api-key
 RAILS_ENV=development
 RAILS_HOST=localhost:5000
 RAILS_PROTOCOL=http

--- a/template.rb
+++ b/template.rb
@@ -59,6 +59,7 @@ def apply_self!
     run 'cp config/webpack/production.js config/webpack/staging.js'
     run 'cp config/environments/production.rb config/environments/staging.rb'
     run 'rubocop -A'
+    run 'overcommit --install'
 
     git :init unless existing_repository?
     git checkout: "-b main" unless existing_commits?


### PR DESCRIPTION
Because

* Airships rails projects use bugsnag to track unhandled exceptions.

This commit:

* Adds a new bugsnag initializer.