### PR TITLE
Test Suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem 'webpacker', '~> 4.0'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'dotenv-rails', '~> 2.7'
-  gem 'factory_bot_rails', '~> 6.1'
-  gem 'faker', '~> 2.11.0'
+  gem 'dotenv-rails'
+  gem 'factory_bot_rails'
+  gem 'faker'
   gem 'guard'
   gem 'guard-brakeman'
   gem 'guard-minitest'
@@ -38,16 +38,17 @@ end
 
 group :development do
   gem 'foreman'
-  gem 'listen', '~> 3.2'
+  gem 'listen'
   gem 'overcommit'
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'web-console', '>= 3.3.0'
+  gem 'spring-watcher-listen'
+  gem 'web-console'
 end
 
 group :test do
-  gem 'capybara', '>= 2.15'
+  gem 'capybara'
   gem 'database_cleaner'
+  gem 'minitest-retry'
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,46 +1,20 @@
-require 'rails/generators/migration'
-require 'rails/generators/actions/create_migration'
-require 'rails/generators/named_base'
+require 'rails/generators'
 
 Rails.application.config.generators do |g|
-  # Disable generators we don't need.
   g.javascripts false
   g.stylesheets false
 end
 
-module AddFrozenStringLiteralComment
-  def add_frozen_string_literal_comment(dist)
-    return unless File.exist?(dist) && File.extname(dist) == '.rb'
+return unless defined?(::Rails::Generators)
 
-    File.open(dist, 'r') do |f|
-      body = f.read
+module RailsGeneratorFrozenStringLiteralPrepend
+  RUBY_EXTENSIONS = %w[.rb .rake]
 
-      File.open(dist, 'w') do |new_f|
-        new_f.write("# frozen_string_literal: true\n\n" + body)
-      end
-    end
+  def render
+    RUBY_EXTENSIONS.include?(File.extname(self.destination)) &&
+      "# frozen_string_literal: true\n\n" + super ||
+      super
   end
 end
 
-module GeneratorPrepend
-  include AddFrozenStringLiteralComment
-
-  def invoke!
-    res = super
-    add_frozen_string_literal_comment(existing_migration)
-    res
-  end
-end
-
-module TemplatePrepend
-  include AddFrozenStringLiteralComment
-
-  def template(source, *args, &block)
-    res = super
-    add_frozen_string_literal_comment(args.first)
-    res
-  end
-end
-
-Rails::Generators::Actions::CreateMigration.prepend GeneratorPrepend
-Rails::Generators::NamedBase.prepend TemplatePrepend
+Thor::Actions::CreateFile.prepend RailsGeneratorFrozenStringLiteralPrepend

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
+  NewCops: enable
   Exclude:
     - db/schema.rb
     - db/seeds/**/*
@@ -211,8 +212,6 @@ Style/Documentation:
 
 Style/ExplicitBlockArgument:
   Enabled: true
-  Exclude:
-    - app/domain/application_handler.rb
 
 Style/ExponentialNotation:
   Enabled: true

--- a/template.rb
+++ b/template.rb
@@ -45,6 +45,7 @@ def apply_self!
 
   apply 'circleci/template.rb'
   apply 'config/template.rb'
+  apply 'test/template.rb'
 
   if yes?('Do you use rvm?')
     template 'ruby-gemset.tt', '.ruby-gemset', force: true
@@ -55,6 +56,7 @@ def apply_self!
     run 'bin/setup'
     rails_command 'active_storage:install'
     rails_command 'db:migrate'
+    generate 'pundit:install'
 
     run 'cp config/webpack/production.js config/webpack/staging.js'
     run 'cp config/environments/production.rb config/environments/staging.rb'

--- a/test/support/circleci.rb
+++ b/test/support/circleci.rb
@@ -1,0 +1,1 @@
+require "minitest/ci" if ENV["CIRCLECI"]

--- a/test/support/cleaner.rb
+++ b/test/support/cleaner.rb
@@ -1,0 +1,5 @@
+DatabaseCleaner.strategy = :truncation
+
+class ActiveSupport::TestCase
+  teardown { DatabaseCleaner.clean }
+end

--- a/test/support/factorybot.rb
+++ b/test/support/factorybot.rb
@@ -1,0 +1,3 @@
+class ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+end

--- a/test/support/faker.rb
+++ b/test/support/faker.rb
@@ -1,0 +1,3 @@
+class ActiveSupport::TestCase
+  teardown { Faker::UniqueGenerator.clear }
+end

--- a/test/support/mailer.rb
+++ b/test/support/mailer.rb
@@ -1,0 +1,3 @@
+class ActiveSupport::TestCase
+  teardown { ActionMailer::Base.deliveries.clear }
+end

--- a/test/support/rails.rb
+++ b/test/support/rails.rb
@@ -1,0 +1,9 @@
+ENV["RAILS_ENV"] ||= 'test'
+require_relative '../../config/environment'
+require 'rails/test_help'
+
+class ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+
+  fixtures :all
+end

--- a/test/support/retry.rb
+++ b/test/support/retry.rb
@@ -1,0 +1,3 @@
+require 'minitest/retry'
+
+Minitest::Retry.use!

--- a/test/template.rb
+++ b/test/template.rb
@@ -1,0 +1,8 @@
+copy_file 'test/test_helper.rb', force: true
+copy_file 'test/support/circleci.rb'
+copy_file 'test/support/cleaner.rb'
+copy_file 'test/support/factorybot.rb'
+copy_file 'test/support/faker.rb'
+copy_file 'test/support/mailer.rb'
+copy_file 'test/support/rails.rb'
+copy_file 'test/support/retry.rb'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,3 @@
+require_relative './support/rails'
+
+Dir[Rails.root.join('test/support/**/*.rb')].sort.each { |f| require f }


### PR DESCRIPTION
Because

Airship rails project test suites:

* need a database cleaner strategy
* use factory bot
* use faker

This commit:

* Sets up the application template to have some test suite support
defaults including:
  * A truncation database cleaner strategy.
  * A default retry strategy.
  * Updates test cases to include factorybot methods.