### PR TITLE
Update Ruby Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bugsnag'

--- a/foreman
+++ b/foreman
@@ -1,1 +1,2 @@
 procfile: Procfile.dev
+port: 3000


### PR DESCRIPTION
Because

* Circle CI has deprecated its browser tools orb for ruby 2.7.1

This commit:

* Updates railyard to use ruby 2.7.2 as the default ruby version.