### PR TITLE
Blueprint/rails: simple_form option

### DIFF
--- a/rails/blueprints/simple_form/template.rb
+++ b/rails/blueprints/simple_form/template.rb
@@ -10,6 +10,8 @@ def apply_self!
       gem "simple_form-tailwind"
       run "bundle install"
       generate "simple_form:tailwind:install"
+    else
+      generate "simple_form:install"
     end
   end
 end

--- a/rails/blueprints/simple_form/template.rb
+++ b/rails/blueprints/simple_form/template.rb
@@ -1,0 +1,17 @@
+def apply_self!
+  if yes?("Would you like to install Simple Form?")
+    gem "simple_form"
+    run "bundle install"
+
+    if yes?("Do you use Bootstrap?")
+      generate "simple_form:install --bootstrap"
+    elsif yes?("Do you use Tailwind?")
+      generate "simple_form:install"
+      gem "simple_form-tailwind"
+      run "bundle install"
+      generate "simple_form:tailwind:install"
+    end
+  end
+end
+
+apply_self!


### PR DESCRIPTION
Adds a simple form option to the Rails blueprints. Gives two default options:
- Bootstrap option: Built in to simple form.
- Tailwind option
    - Provided by external gem: https://github.com/tarellel/simple_form-tailwind