### PR TITLE
Feature/ROCK-7 - make tailwind optional

### DIFF
--- a/lib/railyard/cli.rb
+++ b/lib/railyard/cli.rb
@@ -9,7 +9,7 @@ module Railyard
 
     desc "create APP", "creates a new rails app"
     def create(app)
-      run "rails new #{app} -d postgresql -j esbuild -c tailwind -m ./rails/template.rb"
+      run "rails new #{app} -d postgresql -j esbuild -m ./rails/template.rb"
     end
 
     private

--- a/rails/blueprints/css/template.rb
+++ b/rails/blueprints/css/template.rb
@@ -1,0 +1,11 @@
+def apply_self!
+  if yes?("Would you like to use tailwind?")
+    gem "tailwindcss-rails"
+    run "bundle install"
+
+    ask("*** NOTE: If you are prompted to 'overwrite' ./bin/dev, press Y. Press enter to continue. ***", :blue)
+    run "rails tailwindcss:install"
+  end
+end
+
+apply_self!


### PR DESCRIPTION
Makes tailwind optional rather than a basic part of install.